### PR TITLE
Fix broken PyScript JavaScript and CSS links

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.1/jquery.min.js"></script>
 
 		<!-- Pyscript -->
-		<script defer src="https://pyscript.net/latest/pyscript.js"></script>
-		<link rel="stylesheet" href="https://pyscript.net/latest/pyscript.css" />
+		<script defer src="https://pyscript.net/releases/2023.05.1/pyscript.js"></script>
+		<link rel="stylesheet" href="https://pyscript.net/releases/2023.05.1/pyscript.css" />
 
 		<!-- jstree -->
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.2.1/themes/default/style.min.css" />


### PR DESCRIPTION
PyScript [no longer serves releases under the `latest` label], which causes the demo website to fail silently. This change updates the linked resources to explicitly point to what would have been the latest PyScript release at the time of the [last deployment] as a short-term fix.

[no longer serves releases under the `latest` label]: https://docs.pyscript.net/2025.8.1/faq/#pyscript-latest
[last deployment]: https://github.com/Apollo-Roboto/python-pathschema/commit/4a321c6bb4422706492fda101145919b904beb12